### PR TITLE
Pass3: normalize Yann LeCun variants to 'Yann Le Cun'

### DIFF
--- a/src/components/transcribe/utils/utils.ts
+++ b/src/components/transcribe/utils/utils.ts
@@ -174,6 +174,22 @@ function normalizeLooseName(s: string): string {
     .trim();
 }
 
+function normalizeDenseName(s: string): string {
+  return normalizeLooseName(s).replace(/\s+/g, "");
+}
+
+function canonicalizeSpeakerName(name: string): string {
+  const dense = normalizeDenseName(name);
+
+  // Canonical spellings for known recurring variants.
+  const CANONICAL_BY_DENSE: Record<string, string> = {
+    yannlecun: "Yann Le Cun",
+    yannlecunn: "Yann Le Cun",
+  };
+
+  return CANONICAL_BY_DENSE[dense] || name;
+}
+
 function isAllowedSingleTokenName(name: string): boolean {
   const n = normalizeLooseName(name);
   // Celebrity/stage-name exceptions that are valid speaker outputs.
@@ -271,15 +287,19 @@ export async function verifyAndCleanSpeakers(
       .map((n) => n.trim())
       .filter((n) => n.split(/\s+/).length >= 2 || isAllowedSingleTokenName(n))
       .filter((n) => candidateSet.has(n.toLowerCase()))
+      .map(canonicalizeSpeakerName)
       .join(", ");
 
     return finalNames;
   } catch (error) {
     console.error("Error in third-pass speaker verification:", error);
     // Safe fallback: clean pass2 only, never add.
-    return candidateList
-      .filter((n) => n.split(/\s+/).length >= 2 || isAllowedSingleTokenName(n))
-      .join(", ");
+    return deduplicateAndFormatNames(
+      candidateList
+        .filter((n) => n.split(/\s+/).length >= 2 || isAllowedSingleTokenName(n))
+        .map(canonicalizeSpeakerName)
+        .join(", "),
+    );
   }
 }
 


### PR DESCRIPTION
Implements pass3 canonicalization so future outputs use a single spelling for Yann LeCun variants.

What it does:
- Adds pass3 canonical-name rewrite map
- Rewrites "Yann LeCun", "Yann Lecun", and "Yann Le Cunn" to "Yann Le Cun"
- Applies rewrite both in normal pass3 output and fallback path

This keeps browse speaker URLs/counts from splitting across spelling variants going forward.
