### PR TITLE
Fix build: resolve duplicate pass3 canonicalize function

### DIFF
--- a/src/components/transcribe/utils/utils.ts
+++ b/src/components/transcribe/utils/utils.ts
@@ -167,6 +167,7 @@ const SPEAKER_NAME_CANONICAL: Record<string, string> = {
   "yann le cun": "Yann LeCun",
   "yann le cunn": "Yann LeCun",
   "yann lecun": "Yann LeCun",
+  "yann lecunn": "Yann LeCun",
 };
 
 /**
@@ -194,21 +195,6 @@ function normalizeLooseName(s: string): string {
     .trim();
 }
 
-function normalizeDenseName(s: string): string {
-  return normalizeLooseName(s).replace(/\s+/g, "");
-}
-
-function canonicalizeSpeakerName(name: string): string {
-  const dense = normalizeDenseName(name);
-
-  // Canonical spellings for known recurring variants.
-  const CANONICAL_BY_DENSE: Record<string, string> = {
-    yannlecun: "Yann Le Cun",
-    yannlecunn: "Yann Le Cun",
-  };
-
-  return CANONICAL_BY_DENSE[dense] || name;
-}
 
 function isAllowedSingleTokenName(name: string): boolean {
   const n = normalizeLooseName(name);


### PR DESCRIPTION
Fixes the failed deploy by removing duplicate `canonicalizeSpeakerName` declarations introduced by overlapping PRs.

Keeps canonical speaker normalization in pass3 with `Yann LeCun` as the canonical output, including variants:
- Yann Le Cun
- Yann Le Cunn
- Yann Lecun
- Yann Lecunn

This preserves the requested behavior while restoring a clean build.
