### PR TITLE
feat: right-side video + transcript pane from timestamp clicks

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,16 +1,41 @@
 "use client";
 
 import { Loader } from "@/components/loader";
-import { useActionState, useState } from "react";
+import { useState } from "react";
 import { ErrorMessage } from "../error-message";
 import { SearchForm } from "./search-form";
-import { searchTranscript } from "./utils/actions";
 import { VideoResult } from "./video-result";
 import { VideoResult as VideoResultType } from "./utils/types";
 import { Export } from "./export";
+import { VideoPane } from "./video-pane";
+
+type SelectedClip = {
+  videoId: string;
+  startSec: number;
+  snippetHtml?: string;
+  videoTitle: string;
+  channelName: string;
+};
+
 export function App() {
   const [data, setData] = useState<Record<string, any>>();
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedClip, setSelectedClip] = useState<SelectedClip | null>(null);
+
+  const handleTimestampClick = (
+    video: VideoResultType,
+    seconds: number,
+    snippetHtml?: string,
+  ) => {
+    setSelectedClip({
+      videoId: video.ID,
+      startSec: seconds,
+      snippetHtml,
+      videoTitle: video.Video_Title,
+      channelName: video.Channel_Name,
+    });
+  };
+
   return (
     <>
       <SearchForm
@@ -38,10 +63,26 @@ export function App() {
           </p>
         </div>
       ) : (
-        <div className="space-y-4">
-          {data?.results?.map((video: VideoResultType, index: number) => (
-            <VideoResult video={video} key={`${video.ID}-${index}`} />
-          ))}
+        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_430px] gap-4 items-start">
+          <div className="space-y-4">
+            {data?.results?.map((video: VideoResultType, index: number) => (
+              <VideoResult
+                video={video}
+                key={`${video.ID}-${index}`}
+                onTimestampClick={handleTimestampClick}
+              />
+            ))}
+          </div>
+
+          {selectedClip && (
+            <VideoPane
+              videoId={selectedClip.videoId}
+              startSec={selectedClip.startSec}
+              snippetHtml={selectedClip.snippetHtml}
+              videoTitle={selectedClip.videoTitle}
+              channelName={selectedClip.channelName}
+            />
+          )}
         </div>
       )}
     </>

--- a/src/components/search/match-snippets.tsx
+++ b/src/components/search/match-snippets.tsx
@@ -19,9 +19,15 @@ type Props = {
   /** Snippet objects with pre-computed timestamps returned by search. */
   snippets: { text: string; seconds: number | null }[];
   className?: string;
+  onTimestampClick?: (seconds: number, snippetHtml?: string) => void;
 };
 
-export function MatchSnippets({ videoId, snippets, className }: Props) {
+export function MatchSnippets({
+  videoId,
+  snippets,
+  className,
+  onTimestampClick,
+}: Props) {
   return (
     <div className={className}>
       <div className="text-sm text-gray-800 mb-2 font-medium">
@@ -38,12 +44,22 @@ export function MatchSnippets({ videoId, snippets, className }: Props) {
           >
             {/* clickable timestamp */}
             {seconds !== null ? (
-              <Link
-                href={`/video/${videoId}?t=${seconds}`}
-                className="text-blue-600 hover:underline shrink-0"
-              >
-                {fmt(seconds)}
-              </Link>
+              onTimestampClick ? (
+                <button
+                  type="button"
+                  onClick={() => onTimestampClick(seconds, snippet.text)}
+                  className="text-blue-600 hover:underline shrink-0"
+                >
+                  {fmt(seconds)}
+                </button>
+              ) : (
+                <Link
+                  href={`/video/${videoId}?t=${seconds}`}
+                  className="text-blue-600 hover:underline shrink-0"
+                >
+                  {fmt(seconds)}
+                </Link>
+              )
             ) : (
               <span className="text-gray-400 shrink-0">--:--</span>
             )}

--- a/src/components/search/video-pane.tsx
+++ b/src/components/search/video-pane.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import TranscriptPane from "@/components/TranscriptPane";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  videoId: string;
+  startSec: number;
+  snippetHtml?: string;
+  videoTitle: string;
+  channelName: string;
+};
+
+export function VideoPane({
+  videoId,
+  startSec,
+  snippetHtml,
+  videoTitle,
+  channelName,
+}: Props) {
+  const params = new URLSearchParams({
+    start: String(startSec),
+    autoplay: "1",
+    enablejsapi: "1",
+    cc_load_policy: "1",
+    cc_lang_pref: "en",
+    rel: "0",
+    modestbranding: "1",
+  });
+
+  return (
+    <Card className="xl:sticky xl:top-4 border-blue-200 shadow-sm">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Video preview</CardTitle>
+        <p className="text-xs text-gray-600 line-clamp-2">{videoTitle}</p>
+        <p className="text-xs text-gray-500">{channelName}</p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="w-full aspect-video rounded-md overflow-hidden border">
+          <iframe
+            id={`player-${videoId}`}
+            key={`${videoId}-${startSec}`}
+            className="w-full h-full"
+            src={`https://www.youtube.com/embed/${videoId}?${params.toString()}`}
+            title={`Video preview: ${videoTitle}`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+
+        {snippetHtml && (
+          <div className="rounded-md border bg-gray-50 p-2 text-sm leading-relaxed">
+            <p className="text-[11px] uppercase tracking-wide text-gray-500 mb-1">
+              Matched snippet
+            </p>
+            <div
+              className="[&>mark]:bg-yellow-200 [&>mark]:font-semibold"
+              dangerouslySetInnerHTML={{ __html: snippetHtml }}
+            />
+          </div>
+        )}
+
+        <TranscriptPane
+          videoId={videoId}
+          height={360}
+          sentencesPerPara={3}
+          initialTimestamp={startSec}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/search/video-result.tsx
+++ b/src/components/search/video-result.tsx
@@ -7,7 +7,16 @@ import { VideoResult as VideoResultType } from "./utils/types";
 import { VideoLength } from "./video-length";
 import { TranscriptDialog } from "./transcript-dialog";
 
-export function VideoResult({ video }: { video: VideoResultType }) {
+type Props = {
+  video: VideoResultType;
+  onTimestampClick?: (
+    video: VideoResultType,
+    seconds: number,
+    snippetHtml?: string,
+  ) => void;
+};
+
+export function VideoResult({ video, onTimestampClick }: Props) {
   return (
     <Card className="hover:border-blue-200 transition-all">
       <CardContent>
@@ -51,12 +60,15 @@ export function VideoResult({ video }: { video: VideoResultType }) {
             <TranscriptDialog video={video} />
           </div>
         </div>
-         {video.MatchSnippets && video.MatchSnippets.length > 0 && (
-           <MatchSnippets
-             videoId={video.ID}            // ← ID is the YouTube id from BigQuery
-             snippets={video.MatchSnippets}
-             className="mt-4"
-           />
+        {video.MatchSnippets && video.MatchSnippets.length > 0 && (
+          <MatchSnippets
+            videoId={video.ID}
+            snippets={video.MatchSnippets}
+            className="mt-4"
+            onTimestampClick={(seconds, snippetHtml) =>
+              onTimestampClick?.(video, seconds, snippetHtml)
+            }
+          />
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- open a sticky right-side preview pane on search/chat page when timestamp links are clicked
- keep users on the same page and swap player/transcript when a different timestamp is clicked
- embed YouTube with captions on by default ()
- include a compact matched-snippet card and scrollable transcript pane

## Testing
- npm run build

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tallchap/flatcreepyinformation/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
