### PR TITLE
feat(chat): in-tab video preview pane + disable transcript auto-scroll

### DIFF
--- a/src/components/TranscriptPane.tsx
+++ b/src/components/TranscriptPane.tsx
@@ -4,7 +4,13 @@ import { useEffect, useRef, useState, useCallback } from "react";
 type Line = { start: number; text: string };
 type Paragraph = { start: number; lines: Line[] };
 type ActivePos = { para: number; line: number } | null;
-type Props = { videoId: string; height?: number; sentencesPerPara?: number; initialTimestamp?: number | null };
+type Props = {
+  videoId: string;
+  height?: number;
+  sentencesPerPara?: number;
+  initialTimestamp?: number | null;
+  autoScrollToActive?: boolean;
+};
 
 /** Find the paragraph + line matching a given timestamp. */
 function findPositionForTime(paras: Paragraph[], t: number): ActivePos {
@@ -26,6 +32,7 @@ export default function TranscriptPane({
   height = 300, // Reduced default height
   sentencesPerPara = 4, // Fewer sentences per paragraph
   initialTimestamp = null,
+  autoScrollToActive = true,
 }: Props) {
   const [paras, setParas] = useState<Paragraph[]>([]);
   const [active, setActive] = useState<ActivePos>(null);
@@ -119,10 +126,11 @@ export default function TranscriptPane({
 
   /* 3b ▸ SCROLL TO ACTIVE LINE */
   useEffect(() => {
+    if (!autoScrollToActive) return;
     if (activeLineRef.current) {
       activeLineRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
     }
-  }, [active]);
+  }, [active, autoScrollToActive]);
 
   /* 3c ▸ KEEP ACTIVE REF IN SYNC */
   useEffect(() => {

--- a/src/components/chat/chat-window.tsx
+++ b/src/components/chat/chat-window.tsx
@@ -6,11 +6,18 @@ import { Button } from "@/components/ui/button";
 import { SPEAKER_ASSISTANTS } from "@/lib/assistants";
 import { SpeakerSelect } from "./speaker-select";
 import { MessageBubble } from "./message-bubble";
+import { VideoPreviewPane } from "./video-preview-pane";
 
 interface Message {
   role: "user" | "assistant";
   content: string;
 }
+
+type SelectedVideo = {
+  videoId: string;
+  startSec: number;
+  title?: string;
+} | null;
 
 export function ChatWindow() {
   const [speaker, setSpeaker] = useState("");
@@ -18,6 +25,7 @@ export function ChatWindow() {
   const [input, setInput] = useState("");
   const [threadId, setThreadId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedVideo, setSelectedVideo] = useState<SelectedVideo>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -34,6 +42,7 @@ export function ChatWindow() {
     setThreadId(null);
     setInput("");
     setIsLoading(false);
+    setSelectedVideo(null);
   }
 
   function handleSpeakerChange(value: string) {
@@ -174,98 +183,109 @@ export function ChatWindow() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-160px)] max-w-4xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-4 pb-4 border-b border-gray-200">
-        <div className="flex items-center gap-3">
-          <SpeakerSelect
-            value={speaker}
-            onValueChange={handleSpeakerChange}
-            disabled={isLoading}
-          />
-          {messages.length > 0 && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleNewConversation}
-              disabled={isLoading}
-            >
-              <RotateCcw className="h-4 w-4 mr-1" />
-              New Chat
-            </Button>
-          )}
-        </div>
-      </div>
-
-      {/* Messages area */}
-      <div className="flex-1 overflow-y-auto py-4 space-y-4">
-        {!speaker && (
-          <div className="flex items-center justify-center h-full text-gray-400">
-            <p className="text-lg">Select a speaker to start chatting</p>
-          </div>
-        )}
-
-        {speaker && messages.length === 0 && (
-          <div className="flex items-center justify-center h-full text-gray-400">
-            <div className="text-center space-y-2">
-              <p className="text-lg">
-                Chat with{" "}
-                <span className="font-semibold text-gray-600">
-                  {SPEAKER_ASSISTANTS.find((s) => s.slug === speaker)
-                    ?.name ?? speaker}
-                </span>
-                &apos;s transcript history
-              </p>
-              <p className="text-sm">
-                Ask about their views, find specific quotes, or explore topics
-                they&apos;ve discussed.
-              </p>
-            </div>
-          </div>
-        )}
-
-        {messages.map((msg, i) => (
-          <MessageBubble
-            key={i}
-            role={msg.role}
-            content={msg.content}
-            isStreaming={
-              isLoading &&
-              i === messages.length - 1 &&
-              msg.role === "assistant"
-            }
-          />
-        ))}
-        <div ref={messagesEndRef} />
-      </div>
-
-      {/* Input area */}
-      {speaker && (
-        <div className="border-t border-gray-200 pt-4">
-          <div className="flex items-end gap-2">
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Ask about their views, find quotes, explore topics..."
-              className="flex-1 resize-none rounded-xl border border-gray-300 bg-white px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-[#99cc66] focus:border-transparent min-h-[48px] max-h-[120px]"
-              rows={1}
+    <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_420px] gap-4 items-start">
+      <div className="flex flex-col h-[calc(100vh-160px)] min-w-0">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-4 pb-4 border-b border-gray-200">
+          <div className="flex items-center gap-3">
+            <SpeakerSelect
+              value={speaker}
+              onValueChange={handleSpeakerChange}
               disabled={isLoading}
             />
-            <Button
-              onClick={handleSend}
-              disabled={!input.trim() || isLoading}
-              className="bg-[#99cc66] hover:bg-[#88bb55] text-white rounded-xl h-[48px] w-[48px] p-0"
-            >
-              <Send className="h-5 w-5" />
-            </Button>
+            {messages.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleNewConversation}
+                disabled={isLoading}
+              >
+                <RotateCcw className="h-4 w-4 mr-1" />
+                New Chat
+              </Button>
+            )}
           </div>
-          <p className="text-xs text-gray-400 mt-2 text-center">
-            Responses are based on video transcript data. Always verify quotes
-            against the original videos.
-          </p>
         </div>
+
+        {/* Messages area */}
+        <div className="flex-1 overflow-y-auto py-4 space-y-4">
+          {!speaker && (
+            <div className="flex items-center justify-center h-full text-gray-400">
+              <p className="text-lg">Select a speaker to start chatting</p>
+            </div>
+          )}
+
+          {speaker && messages.length === 0 && (
+            <div className="flex items-center justify-center h-full text-gray-400">
+              <div className="text-center space-y-2">
+                <p className="text-lg">
+                  Chat with{" "}
+                  <span className="font-semibold text-gray-600">
+                    {SPEAKER_ASSISTANTS.find((s) => s.slug === speaker)
+                      ?.name ?? speaker}
+                  </span>
+                  &apos;s transcript history
+                </p>
+                <p className="text-sm">
+                  Ask about their views, find specific quotes, or explore topics
+                  they&apos;ve discussed.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {messages.map((msg, i) => (
+            <MessageBubble
+              key={i}
+              role={msg.role}
+              content={msg.content}
+              isStreaming={
+                isLoading &&
+                i === messages.length - 1 &&
+                msg.role === "assistant"
+              }
+              onVideoLinkClick={(payload) => setSelectedVideo(payload)}
+            />
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input area */}
+        {speaker && (
+          <div className="border-t border-gray-200 pt-4">
+            <div className="flex items-end gap-2">
+              <textarea
+                ref={inputRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Ask about their views, find quotes, explore topics..."
+                className="flex-1 resize-none rounded-xl border border-gray-300 bg-white px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-[#99cc66] focus:border-transparent min-h-[48px] max-h-[120px]"
+                rows={1}
+                disabled={isLoading}
+              />
+              <Button
+                onClick={handleSend}
+                disabled={!input.trim() || isLoading}
+                className="bg-[#99cc66] hover:bg-[#88bb55] text-white rounded-xl h-[48px] w-[48px] p-0"
+              >
+                <Send className="h-5 w-5" />
+              </Button>
+            </div>
+            <p className="text-xs text-gray-400 mt-2 text-center">
+              Responses are based on video transcript data. Always verify quotes
+              against the original videos.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {selectedVideo && (
+        <VideoPreviewPane
+          videoId={selectedVideo.videoId}
+          startSec={selectedVideo.startSec}
+          title={selectedVideo.title}
+        />
       )}
     </div>
   );

--- a/src/components/chat/message-bubble.tsx
+++ b/src/components/chat/message-bubble.tsx
@@ -6,6 +6,7 @@ interface MessageBubbleProps {
   role: "user" | "assistant";
   content: string;
   isStreaming?: boolean;
+  onVideoLinkClick?: (payload: { videoId: string; startSec: number; title?: string }) => void;
 }
 
 /**
@@ -21,12 +22,12 @@ function formatContent(text: string): string {
       // Bold **text**
       .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
       // Snippysaurus video links: [Video Title](youtube:VIDEO_ID) or [Video Title](youtube:VIDEO_ID:SECONDS)
-      // Allow one level of nested brackets (e.g. "[Percontations]") but prevent spanning across separate link constructs
       .replace(
         /\[((?:[^\[\]]|\[[^\]]*\])*)\]\(youtube:([\w-]{11})(?::(\d+(?:\.\d+)?))?\)/g,
         (_match, title: string, videoId: string, seconds?: string) => {
-          const href = seconds ? `/video/${videoId}?t=${Math.floor(parseFloat(seconds))}` : `/video/${videoId}`;
-          return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 underline text-blue-600 hover:text-blue-800"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>${title}</a>`;
+          const startSec = seconds ? Math.floor(parseFloat(seconds)) : 0;
+          const href = `/video/${videoId}?t=${startSec}`;
+          return `<a href="${href}" data-video-id="${videoId}" data-start-sec="${startSec}" data-video-title="${encodeURIComponent(title)}" class="inline-flex items-center gap-1 underline text-blue-600 hover:text-blue-800"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>${title}</a>`;
         },
       )
       // Regular markdown links [text](url)
@@ -34,10 +35,10 @@ function formatContent(text: string): string {
         /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
         '<a href="$2" target="_blank" rel="noopener noreferrer" class="underline text-blue-600 hover:text-blue-800">$1</a>',
       )
-      // Bare YouTube URLs
+      // Bare youtu.be URLs
       .replace(
         /(https:\/\/youtu\.be\/([\w-]{11}))/g,
-        '<a href="/video/$2" target="_blank" rel="noopener noreferrer" class="underline text-blue-600 hover:text-blue-800">$1</a>',
+        '<a href="/video/$2" data-video-id="$2" data-start-sec="0" class="underline text-blue-600 hover:text-blue-800">$1</a>',
       )
       // Newlines
       .replace(/\n/g, "<br />")
@@ -48,8 +49,25 @@ export function MessageBubble({
   role,
   content,
   isStreaming,
+  onVideoLinkClick,
 }: MessageBubbleProps) {
   const isUser = role === "user";
+
+  function handleAssistantContentClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (!onVideoLinkClick) return;
+    const target = e.target as HTMLElement;
+    const link = target.closest("a[data-video-id]") as HTMLAnchorElement | null;
+    if (!link) return;
+
+    const videoId = link.dataset.videoId;
+    if (!videoId) return;
+
+    e.preventDefault();
+    const startSec = Number(link.dataset.startSec || "0") || 0;
+    const encodedTitle = link.dataset.videoTitle;
+    const title = encodedTitle ? decodeURIComponent(encodedTitle) : link.textContent || undefined;
+    onVideoLinkClick({ videoId, startSec, title });
+  }
 
   return (
     <div
@@ -69,6 +87,7 @@ export function MessageBubble({
         ) : (
           <div
             className="prose prose-sm max-w-none"
+            onClick={handleAssistantContentClick}
             dangerouslySetInnerHTML={{ __html: formatContent(content) }}
           />
         )}

--- a/src/components/chat/video-preview-pane.tsx
+++ b/src/components/chat/video-preview-pane.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import TranscriptPane from "@/components/TranscriptPane";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  videoId: string;
+  startSec: number;
+  title?: string;
+};
+
+export function VideoPreviewPane({ videoId, startSec, title }: Props) {
+  const params = new URLSearchParams({
+    start: String(startSec),
+    autoplay: "1",
+    enablejsapi: "1",
+    cc_load_policy: "1",
+    cc_lang_pref: "en",
+    rel: "0",
+    modestbranding: "1",
+  });
+
+  return (
+    <Card className="xl:sticky xl:top-4 border-blue-200 shadow-sm h-fit">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Video preview</CardTitle>
+        {title && <p className="text-xs text-gray-600 line-clamp-2">{title}</p>}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="w-full aspect-video rounded-md overflow-hidden border">
+          <iframe
+            id={`player-${videoId}`}
+            key={`${videoId}-${startSec}`}
+            className="w-full h-full"
+            src={`https://www.youtube.com/embed/${videoId}?${params.toString()}`}
+            title={title ?? `Video preview ${videoId}`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+
+        <TranscriptPane
+          videoId={videoId}
+          height={340}
+          sentencesPerPara={3}
+          initialTimestamp={startSec}
+          autoScrollToActive={false}
+        />
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary\n- add right-side video preview pane inside the Chat tab when citation links are clicked\n- keep user in chat page and swap preview player/transcript for newly clicked links\n- keep YouTube captions on by default in preview player\n- disable transcript auto-scroll in preview pane so page remains usable\n\n## Testing\n- npm run build\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tallchap/flatcreepyinformation/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
