### PR TITLE
Fix chat preview transcript sync + quote start timestamp

### DIFF
--- a/src/components/TranscriptPane.tsx
+++ b/src/components/TranscriptPane.tsx
@@ -10,6 +10,7 @@ type Props = {
   sentencesPerPara?: number;
   initialTimestamp?: number | null;
   autoScrollToActive?: boolean;
+  playerSyncKey?: string | number;
 };
 
 /** Find the paragraph + line matching a given timestamp. */
@@ -33,6 +34,7 @@ export default function TranscriptPane({
   sentencesPerPara = 4, // Fewer sentences per paragraph
   initialTimestamp = null,
   autoScrollToActive = true,
+  playerSyncKey,
 }: Props) {
   const [paras, setParas] = useState<Paragraph[]>([]);
   const [active, setActive] = useState<ActivePos>(null);
@@ -82,21 +84,35 @@ export default function TranscriptPane({
 
   /* 2 ▸ PLAYER SETUP */
   useEffect(() => {
+    playerReadyRef.current = false;
+
+    if (playerRef.current?.destroy) {
+      try {
+        playerRef.current.destroy();
+      } catch {
+        // no-op
+      }
+    }
+    playerRef.current = null;
+
     const mountPlayer = () => {
       if (playerRef.current) return;
       const el = document.getElementById(`player-${videoId}`) as HTMLIFrameElement | null;
       if (el && (window as any).YT?.Player) {
-        if (el.src && !el.src.includes('origin=')) {
-          const sep = el.src.includes('?') ? '&' : '?';
+        if (el.src && !el.src.includes("origin=")) {
+          const sep = el.src.includes("?") ? "&" : "?";
           el.src = `${el.src}${sep}origin=${encodeURIComponent(window.location.origin)}`;
         }
         playerRef.current = new (window as any).YT.Player(el, {
           events: {
-            onReady: () => { playerReadyRef.current = true; },
+            onReady: () => {
+              playerReadyRef.current = true;
+            },
           },
         });
       }
     };
+
     if ((window as any).YT?.Player) {
       mountPlayer();
     } else {
@@ -105,7 +121,19 @@ export default function TranscriptPane({
       document.body.appendChild(s);
       (window as any).onYouTubeIframeAPIReady = mountPlayer;
     }
-  }, [videoId]);
+
+    return () => {
+      if (playerRef.current?.destroy) {
+        try {
+          playerRef.current.destroy();
+        } catch {
+          // no-op
+        }
+      }
+      playerRef.current = null;
+      playerReadyRef.current = false;
+    };
+  }, [videoId, playerSyncKey]);
 
   /* 3 ▸ SYNC & HIGHLIGHT */
   useEffect(() => {

--- a/src/components/chat/video-preview-pane.tsx
+++ b/src/components/chat/video-preview-pane.tsx
@@ -45,6 +45,7 @@ export function VideoPreviewPane({ videoId, startSec, title }: Props) {
           sentencesPerPara={3}
           initialTimestamp={startSec}
           autoScrollToActive={false}
+          playerSyncKey={`${videoId}-${startSec}`}
         />
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- keep transcript word highlighting active in chat video preview while auto-scroll is disabled
- ensure preview player re-initializes when citation start time changes so it always starts at the quote start timestamp

## Validation
- npm run build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tallchap/flatcreepyinformation/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
