### PR TITLE
Fix date-aware citation filtering for chat

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,7 +2,11 @@
 import { NextRequest } from "next/server";
 import OpenAI from "openai";
 import { getAssistantBySlug } from "@/lib/assistants";
-import { fetchTranscript, fetchVideoMeta } from "@/lib/bigquery";
+import {
+  fetchTranscript,
+  fetchVideoMeta,
+  fetchSpeakerVideosBeforeDate,
+} from "@/lib/bigquery";
 import citationMap from "@/lib/file-citation-map.json";
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
@@ -53,6 +57,30 @@ function splitSpeakers(raw: string | null | undefined): string[] | undefined {
     .map((s) => s.trim())
     .filter(Boolean);
   return speakers.length > 0 ? speakers : undefined;
+}
+
+function detectBeforeDateConstraint(message: string): string | null {
+  const lower = message.toLowerCase();
+
+  const explicitDate = lower.match(/\bbefore\s+(\d{4}-\d{2}-\d{2})\b/);
+  if (explicitDate) return explicitDate[1];
+
+  const yearOnly = lower.match(/\bbefore\s+(\d{4})\b/);
+  if (yearOnly) return `${yearOnly[1]}-01-01`;
+
+  return null;
+}
+
+function buildMetadataGuardrailPrompt(
+  originalMessage: string,
+  beforeDate: string,
+  allowedVideos: { id: string; title: string; publishedAt: string }[],
+): string {
+  const allowedList = allowedVideos
+    .map((v) => `- ${v.id} | ${v.publishedAt} | ${v.title}`)
+    .join("\n");
+
+  return `${originalMessage}\n\n[RETRIEVAL_CONSTRAINT]\nThe user asked for videos before ${beforeDate}. You MUST only cite files for videos published before ${beforeDate}.\nIf no relevant clip exists in the allowed set, say so explicitly and do not cite out-of-range videos.\nAllowed videos:\n${allowedList || "- (none found)"}`;
 }
 
 function findTimestampForQuote(
@@ -125,10 +153,29 @@ export async function POST(req: NextRequest) {
       currentThreadId = thread.id;
     }
 
-    // Add user message to thread
+    // Add user message to thread (with metadata guardrails when date constraints are detected)
+    let promptForAssistant = message;
+    const beforeDate = detectBeforeDateConstraint(message);
+    if (beforeDate) {
+      try {
+        const allowedVideos = await fetchSpeakerVideosBeforeDate(
+          assistant.name,
+          beforeDate,
+          300,
+        );
+        promptForAssistant = buildMetadataGuardrailPrompt(
+          message,
+          beforeDate,
+          allowedVideos,
+        );
+      } catch (err) {
+        console.error("Failed to build date guardrail prompt:", err);
+      }
+    }
+
     await openai.beta.threads.messages.create(currentThreadId, {
       role: "user",
-      content: message,
+      content: promptForAssistant,
     });
 
     // Run the assistant and stream the response
@@ -257,6 +304,14 @@ export async function POST(req: NextRequest) {
                   ...(metadataCache[pc.videoId] || {}),
                   ...(pc.metadata || {}),
                 };
+
+                if (
+                  beforeDate &&
+                  mergedMetadata.publishedAt &&
+                  mergedMetadata.publishedAt >= beforeDate
+                ) {
+                  continue;
+                }
 
                 citations[pc.marker] = {
                   videoId: pc.videoId,

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -81,6 +81,35 @@ export async function fetchVideoMeta(id: string) {
 const TABLE = "`youtubetranscripts-429803.reptranscripts.youtube_transcripts`";
 const SPEAKERS_EXPR = `COALESCE(NULLIF(Speakers_GPT_Third, ''), Speakers_Claude)`;
 
+export async function fetchSpeakerVideosBeforeDate(
+  speaker: string,
+  beforeDate: string,
+  limit = 200,
+): Promise<{ id: string; title: string; publishedAt: string }[]> {
+  const [rows] = await bigQuery.query({
+    query: `
+      SELECT
+        ID AS id,
+        Video_Title AS title,
+        CAST(Published_Date AS STRING) AS publishedAt
+      FROM ${TABLE},
+      UNNEST(SPLIT(${SPEAKERS_EXPR}, ',')) AS s
+      WHERE TRIM(s) = @speaker
+        AND Published_Date IS NOT NULL
+        AND Published_Date < DATE(@beforeDate)
+      ORDER BY Published_Date DESC
+      LIMIT @limit
+    `,
+    params: { speaker, beforeDate, limit },
+  });
+
+  return rows.map((r: { id: string; title: string; publishedAt: string }) => ({
+    id: String(r.id),
+    title: String(r.title),
+    publishedAt: String(r.publishedAt),
+  }));
+}
+
 /**
  * Return every distinct speaker (alphabetical) with their video count.
  * Speakers are comma-separated in the source column, so we UNNEST after


### PR DESCRIPTION
Diagnosis: metadata was attached to citations after generation, but retrieval itself was not constrained by date, so out-of-range videos could still be cited.\n\nFixes:\n- detect before-date constraints in chat prompts\n- fetch speaker allowlist of videos before the requested date\n- add strict guardrail prompt so retrieval/citation stays in-range\n- add server-side citation guard to skip out-of-range citations\n\nValidation:\n- npm run build (pass)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tallchap/flatcreepyinformation/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
